### PR TITLE
Feature: add GitHub workflows to build docker containers

### DIFF
--- a/.github/workflows/build-fcode-utils-builder.yml
+++ b/.github/workflows/build-fcode-utils-builder.yml
@@ -1,0 +1,41 @@
+name: Build fcode-utils-builder container
+
+# Run manually from Actions tab
+on: [workflow_dispatch]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-builder
+
+jobs:
+  build-x86_64:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: docker/Dockerfile.builder
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,54 @@
+name: Build fcode-utils
+
+on: [push, workflow_dispatch]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-x86_64:
+    runs-on: ubuntu-latest
+    name: fcode-utils for x86_64
+    steps:
+      - name: Checkout fcode-utils
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build fcode-utils
+        uses: docker://ghcr.io/openbios/fcode-utils-builder:master
+        with:
+          args: "bash -c \"mkdir -p $(pwd)/build-$(uname -m) && make && make DESTDIR=$(pwd)/build-$(uname -m) install\""
+
+      - name: Copy localvalues
+        uses: docker://ghcr.io/openbios/fcode-utils-builder:master
+        with:
+          args: "bash -c \"cp -R localvalues build-$(uname -m)\""
+
+      - name: Store x86_64 artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: fcode-utils-x86_64
+          path: |
+            build-x86_64
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:11.2
+
+COPY build-x86_64/bin/* /usr/bin

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,0 +1,4 @@
+FROM debian:11.2
+
+RUN apt-get -y update && \
+    apt-get -y install build-essential git


### PR DESCRIPTION
This PR is a pre-requisite for an upcoming set of changes to introduce GitHub workflows for building OpenBIOS. It essentially creates 2 separate images and makes them publically available in the Packages tab for the openbios organisation:

  - `ghcr.io/openbios/fcode-utils-builder:master`: a builder image based upon Debian 11.2 containing all of the tools required to build the fcode-utils repository

 - `ghcr.io/openbios/fcode-utils:master`: a standard Debian 11.2 image containing the fcode-utils binaries installed in /usr/bin

The workflows are defined so that they can be manually triggered from the Actions tab by an administrator, and also in the case of a push or merge the existing fcode-utils-builder image is used to generate updated binaries in both the public fcode-utils image and a separate zip artifact.

For examples of how this looks please see my repository at https://github.com/mcayland. Note that last build fails because I changed the workflows to use the images hosted by the openbios organisation rather than myself.