### PR TITLE
toke/Makefile: Declare return type of main in GCC flag probe

### DIFF
--- a/toke/Makefile
+++ b/toke/Makefile
@@ -41,7 +41,7 @@ LDFLAGS =
 # CFLAGS  := $(CFLAGS) -g
 
 # for gcc 4. remove if you fixed the code.
-_GCC4_CFLAGS=$(shell echo 'main(int argc, char **argv){return 0;}' > .test.c;   \
+_GCC4_CFLAGS=$(shell echo 'int main(int argc, char **argv){return 0;}' > .test.c;   \
 		$(CC) -Wno-pointer-sign -c .test.c -o .test.o > /dev/null 2>&1 \
 		&& echo -Wno-pointer-sign; rm .test.c .test.o )
 CFLAGS  := $(CFLAGS) $(_GCC4_CFLAGS)


### PR DESCRIPTION
Without it, the probe may incorrectly fail with future compilers which do not support implicit ints.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
