### PR TITLE
Allow overriding some more Makefile variables

### DIFF
--- a/detok/Makefile
+++ b/detok/Makefile
@@ -24,13 +24,13 @@
 
 PROGRAM = detok
 
-DESTDIR = /usr/local
+DESTDIR ?= /usr/local
 CC      ?= gcc
-STRIP	= strip
+STRIP	?= strip
 INCLUDES = -I../shared
 
 # Normal Flags:
-CFLAGS  = -O2 -Wall #-Wextra
+CFLAGS  ?= -O2 -Wall #-Wextra
 LDFLAGS = 
 
 # Coverage:

--- a/romheaders/Makefile
+++ b/romheaders/Makefile
@@ -24,10 +24,10 @@
 
 PROGRAM = romheaders
 
-DESTDIR  = /usr/local
+DESTDIR  ?= /usr/local
 CC	 ?= gcc
-STRIP    = strip
-CFLAGS   = -O2 -Wall -Wextra
+STRIP    ?= strip
+CFLAGS   ?= -O2 -Wall -Wextra
 INCLUDES = -I../shared
 
 SOURCES = romheaders.c ../shared/classcodes.c

--- a/toke/Makefile
+++ b/toke/Makefile
@@ -24,13 +24,13 @@
 
 PROGRAM = toke
 
-DESTDIR = /usr/local
+DESTDIR ?= /usr/local
 CC      ?= gcc
-STRIP	= strip
+STRIP	?= strip
 INCLUDES = -I../shared
 
 # Normal flags
-CFLAGS  = -O2 -Wall #-Wextra 
+CFLAGS  ?= -O2 -Wall #-Wextra
 LDFLAGS =
 
 # Coverage:


### PR DESCRIPTION
This PR lets anyone to override a few extra variables

* DESTDIR can be set to anything ( /usr for example or any $BUILDROOT/usr)
* STRIP can be set to /bin/true to avoid stripping of debug symbols
* CFLAGS can be set to any preferred value (at your own risk)

Fixes #15.