### PR TITLE
Feature: update GitHub actions

### DIFF
--- a/.github/workflows/build-fcode-utils-builder.yml
+++ b/.github/workflows/build-fcode-utils-builder.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -27,12 +27,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile.builder

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,10 @@ jobs:
     name: fcode-utils for x86_64
     steps:
       - name: Checkout fcode-utils
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -23,7 +23,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -38,14 +38,14 @@ jobs:
           args: "bash -c \"cp -R localvalues build-$(uname -m)\""
 
       - name: Store x86_64 artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: fcode-utils-x86_64
           path: |
             build-x86_64
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,3 @@
-FROM debian:11.2
+FROM debian:12.5
 
 COPY build-x86_64/bin/* /usr/bin

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM debian:11.2
+FROM debian:12.5
 
 RUN apt-get -y update && \
     apt-get -y install build-essential git


### PR DESCRIPTION
This update moves the GitHub actions to the latest version (avoiding deprecation warnings from the workflow runs) whilst also moving the base image up to Debian 12.