### PR TITLE
toke: fix type of olen variable

### DIFF
--- a/toke/emit.c
+++ b/toke/emit.c
@@ -133,7 +133,7 @@ static bool fcode_written = FALSE;
  **************************************************************************** */
 
 extern u8 *ostart;
-extern int olen;
+extern unsigned int olen;
 extern void increase_output_buffer( void);
 
 


### PR DESCRIPTION
The olen variable is declared as unsigned int in toke/stream.c, but simply as int in the extern definition in emit.c. This may cause undefined behaviour, so fix that.