### PR TITLE
toke: fix getopt with invalid combined short options

### DIFF
--- a/toke/toke.c
+++ b/toke/toke.c
@@ -298,7 +298,7 @@ static void get_args( int argc, char **argv )
 			/*  Distinguish between a '?' from the user
 			 *  and one  getopt()  returned
 			 */
-			if ( argv[argindx][1] != '?' )
+			if ( optopt )
 			{
 			    inval_opt = TRUE;
 			    break;


### PR DESCRIPTION
When combining invalid short options, toke just segfaults:

$ toke -ab
 Welcome to toke - FCode tokenizer v1.0.3
 (C) Copyright 2001-2010 Stefan Reinauer.
 (C) Copyright 2006 coresystems GmbH
 (C) Copyright 2005 IBM Corporation.  All Rights Reserved.
 This program is free software; you may redistribute it under the terms of
 the GNU General Public License v2. This program has absolutely no warranty.

 ./toke: invalid option -- 'a'
 ./toke: invalid option -- 'b'
 Segmentation fault (core dumped)

This happens because argindx represent the number of the option, not the number of the argument on the command line. Fix that by looking at the optopt variable instead.