### PR TITLE
Allow overriding LDFLAGS Makefile variables

### DIFF
--- a/detok/Makefile
+++ b/detok/Makefile
@@ -31,7 +31,7 @@ INCLUDES = -I../shared
 
 # Normal Flags:
 CFLAGS  ?= -O2 -Wall #-Wextra
-LDFLAGS = 
+LDFLAGS ?=
 
 # Coverage:
 #CFLAGS  := $(CFLAGS) -fprofile-arcs -ftest-coverage

--- a/romheaders/Makefile
+++ b/romheaders/Makefile
@@ -28,6 +28,7 @@ DESTDIR  ?= /usr/local
 CC	 ?= gcc
 STRIP    ?= strip
 CFLAGS   ?= -O2 -Wall -Wextra
+LDFLAGS  ?=
 INCLUDES = -I../shared
 
 SOURCES = romheaders.c ../shared/classcodes.c
@@ -37,7 +38,7 @@ SOURCES = romheaders.c ../shared/classcodes.c
 all: romheaders
 
 romheaders: $(SOURCES)
-	$(CC) $(CFLAGS) $(INCLUDES) $(SOURCES) -o $@
+	$(CC) $(LDFLAGS) $(CFLAGS) $(INCLUDES) $(SOURCES) -o $@
 	$(STRIP) romheaders
 
 clean:

--- a/toke/Makefile
+++ b/toke/Makefile
@@ -31,7 +31,7 @@ INCLUDES = -I../shared
 
 # Normal flags
 CFLAGS  ?= -O2 -Wall #-Wextra
-LDFLAGS =
+LDFLAGS ?=
 
 # Coverage:
 #CFLAGS  := $(CFLAGS) -fprofile-arcs -ftest-coverage


### PR DESCRIPTION
It could be useful to also override LDFLAGS, for instance to force security related link options. For romheaders, this option has to be added.