### PR TITLE
treewide: DESTDIR -> prefix

### DIFF
--- a/detok/Makefile
+++ b/detok/Makefile
@@ -24,7 +24,7 @@
 
 PROGRAM = detok
 
-DESTDIR ?= /usr/local
+prefix ?= /usr/local
 CC      ?= gcc
 STRIP	?= strip
 INCLUDES = -I../shared
@@ -65,5 +65,5 @@ clean:
 	$(CC) -c $(CFLAGS) $(INCLUDES) $< -o $@ 
 
 install:
-	mkdir -p $(DESTDIR)/bin
-	cp $(PROGRAM) $(DESTDIR)/bin/$(PROGRAM)
+	mkdir -p $(DESTDIR)/$(prefix)/bin
+	cp $(PROGRAM) $(DESTDIR)/$(prefix)/bin/$(PROGRAM)

--- a/romheaders/Makefile
+++ b/romheaders/Makefile
@@ -24,7 +24,7 @@
 
 PROGRAM = romheaders
 
-DESTDIR  ?= /usr/local
+prefix  ?= /usr/local
 CC	 ?= gcc
 STRIP    ?= strip
 CFLAGS   ?= -O2 -Wall -Wextra
@@ -46,5 +46,5 @@ clean:
 	rm -f $(PROGRAM)
 
 install:
-	mkdir -p $(DESTDIR)/bin
-	cp $(PROGRAM) $(DESTDIR)/bin/$(PROGRAM)
+	mkdir -p $(DESTDIR)/$(prefix)/bin
+	cp $(PROGRAM) $(DESTDIR)/$(prefix)/bin/$(PROGRAM)

--- a/toke/Makefile
+++ b/toke/Makefile
@@ -24,7 +24,7 @@
 
 PROGRAM = toke
 
-DESTDIR ?= /usr/local
+prefix ?= /usr/local
 CC      ?= gcc
 STRIP	?= strip
 INCLUDES = -I../shared
@@ -75,5 +75,5 @@ documentation:: *.c *.h toke.doxygen
 	$(CC) -c $(CFLAGS) $(INCLUDES) $< -o $@ 
 
 install:
-	mkdir -p $(DESTDIR)/bin
-	cp $(PROGRAM) $(DESTDIR)/bin/$(PROGRAM)
+	mkdir -p $(DESTDIR)/$(prefix)/bin
+	cp $(PROGRAM) $(DESTDIR)/$(prefix)/bin/$(PROGRAM)


### PR DESCRIPTION
`DESTDIR` is to be set only by the user, to install to a temporary location. `prefix` is what should be used for the install location, and `DESTDIR` is to be prepended to it in the install steps.

Refs:
- `DESTDIR`: https://www.gnu.org/prep/standards/html_node/DESTDIR.html
- `prefix`: https://www.gnu.org/prep/standards/html_node/Directory-Variables.html