### PR TITLE
Fix compile warnings on GCC 15 and enable -Werror

### DIFF
--- a/detok/Makefile
+++ b/detok/Makefile
@@ -30,7 +30,7 @@ STRIP	?= strip
 INCLUDES = -I../shared
 
 # Normal Flags:
-CFLAGS  ?= -O2 -Wall #-Wextra
+CFLAGS  ?= -O2 -Wall -Werror #-Wextra
 LDFLAGS ?=
 
 # Coverage:

--- a/detok/addfcodes.c
+++ b/detok/addfcodes.c
@@ -373,7 +373,7 @@ bool add_fcodes_from_list(char *vf_file_name)
 			int indx;
 			for (indx = 0; indx < spcl_func_count; indx++) {
 				if ( strcmp( vs_fc_name, spcl_func_list[indx].name) == 0 ) {
-					char strbuf[64];
+					char strbuf[90];
 					found_spf = true;
 					spcl_func_list[indx].fcode = vs_fc_number;
 					link_token( &spcl_func_list[indx]);

--- a/detok/decode.c
+++ b/detok/decode.c
@@ -414,10 +414,8 @@ static void decode_branch(void)
 
 static void decode_two(void)
 {
-	u16 token;
-
 	output_token();
-	token = next_token();
+	next_token();
 	output_token_name();
 	printf("\n");
 }

--- a/romheaders/Makefile
+++ b/romheaders/Makefile
@@ -27,7 +27,7 @@ PROGRAM = romheaders
 DESTDIR  ?= /usr/local
 CC	 ?= gcc
 STRIP    ?= strip
-CFLAGS   ?= -O2 -Wall -Wextra
+CFLAGS   ?= -O2 -Wall -Werror -Wextra
 LDFLAGS  ?=
 INCLUDES = -I../shared
 

--- a/toke/Makefile
+++ b/toke/Makefile
@@ -30,7 +30,7 @@ STRIP	?= strip
 INCLUDES = -I../shared
 
 # Normal flags
-CFLAGS  ?= -O2 -Wall #-Wextra
+CFLAGS  ?= -O2 -Wall -Werror #-Wextra
 LDFLAGS ?=
 
 # Coverage:

--- a/toke/conditl.c
+++ b/toke/conditl.c
@@ -210,7 +210,7 @@ static bool already_ignoring = false;
  *
  **************************************************************************** */
 
-void skip_a_word( tic_bool_param_t pfield )
+void skip_a_word( tic_param_t pfield )
 {
     /* signed long wlen = */ get_word();
 }
@@ -238,7 +238,7 @@ void skip_a_word( tic_bool_param_t pfield )
  *          get_word_in_line() will check and report if no word on same line.
  *
  **************************************************************************** */
-void skip_a_word_in_line( tic_bool_param_t pfield )
+void skip_a_word_in_line( tic_param_t pfield )
 {
     /* bool isokay = */ get_word_in_line( statbuf);
 }
@@ -271,7 +271,7 @@ void skip_a_word_in_line( tic_bool_param_t pfield )
  *
  **************************************************************************** */
 
-void skip_two_words_in_line( tic_bool_param_t pfield )
+void skip_two_words_in_line( tic_param_t pfield )
 {
     char *func_cpy = strupr( strdup( statbuf));
     if ( get_word_in_line( func_cpy) )
@@ -646,7 +646,7 @@ static void if_exists( tic_param_t pfield )
  *
  **************************************************************************** */
 
-static void if_not_exist( tic_bool_param_t pfield )
+static void if_not_exist( tic_param_t pfield )
 {
     bool alr_ign = *pfield.bool_ptr;
     conditional_word_in_line( alr_ign, false, exists_in_current );
@@ -663,7 +663,7 @@ static void if_not_exist( tic_bool_param_t pfield )
  *
  **************************************************************************** */
 
-static void if_defined( tic_bool_param_t pfield )
+static void if_defined( tic_param_t pfield )
 {
     bool alr_ign = *pfield.bool_ptr;
     conditional_word_in_line( alr_ign, true, exists_as_user_symbol );
@@ -680,7 +680,7 @@ static void if_defined( tic_bool_param_t pfield )
  *
  **************************************************************************** */
 
-static void if_not_defined( tic_bool_param_t pfield )
+static void if_not_defined( tic_param_t pfield )
 {
     bool alr_ign = *pfield.bool_ptr;
     conditional_word_in_line( alr_ign, false, exists_as_user_symbol );
@@ -704,7 +704,7 @@ static void if_not_defined( tic_bool_param_t pfield )
  *
  **************************************************************************** */
 
-static void if_from_stack( tic_bool_param_t pfield )
+static void if_from_stack( tic_param_t pfield )
 {
     bool alr_ign = *pfield.bool_ptr;
     bool cond = false;

--- a/toke/conditl.h
+++ b/toke/conditl.h
@@ -39,8 +39,8 @@
 
 void init_conditionals_vocab( tic_hdr_t **tic_vocab_ptr );
 
-void skip_a_word( tic_bool_param_t pfield );
-void skip_a_word_in_line( tic_bool_param_t pfield );
-void skip_two_words_in_line( tic_bool_param_t pfield );
+void skip_a_word( tic_param_t pfield );
+void skip_a_word_in_line( tic_param_t pfield );
+void skip_two_words_in_line( tic_param_t pfield );
 
 #endif   /* _TOKE_CONDITL_H    */

--- a/toke/emit.c
+++ b/toke/emit.c
@@ -560,7 +560,6 @@ void finish_pcihdr(void)
 	u32 imageblocks;
 	int padding;
 	
-	rom_header_t *pci_hdr;
 	pci_data_t   *pci_data_blk;
 
 	if( pci_data_blk_ob_off == -1 )
@@ -570,7 +569,6 @@ void finish_pcihdr(void)
 	    return ;
 	}
 
-	pci_hdr = (rom_header_t *)(ostart + pci_hdr_ob_off);
 	pci_data_blk = (pci_data_t *)(ostart + pci_data_blk_ob_off);
 
 	/* fix up vpd */

--- a/toke/macros.c
+++ b/toke/macros.c
@@ -210,8 +210,7 @@ static void macro_recursion_error( tic_param_t pfield)
  *
  **************************************************************************** */
 
-typedef void (*vfunct)();  /*  Pointer to function returning void  */
-static vfunct sav_mac_funct ;
+static void (*sav_mac_funct)(tic_param_t);
 
 
 /* **************************************************************************
@@ -222,8 +221,9 @@ static vfunct sav_mac_funct ;
  *
  **************************************************************************** */
 
-static void mac_string_recovery( tic_hdr_t *macro_entry)
+static void mac_string_recovery( _PTR param)
 {
+    tic_hdr_t *macro_entry = (tic_hdr_t *)param;
     (*macro_entry).funct = sav_mac_funct;
     (*macro_entry).ign_func = sav_mac_funct;
 }
@@ -455,8 +455,9 @@ static void print_if_mac_err( bool failure, char *func_cpy)
 /*  This pointer is exported to this file only  */
 extern tic_hdr_t *tokz_esc_vocab ;
 
-void add_user_macro( void)
+void add_user_macro( tic_param_t pfield )
 {
+    (void)pfield;
     char *macroname;
     char *macrobody;
     bool failure = true;
@@ -533,7 +534,7 @@ void add_user_macro( void)
  *              invokes a directive that alters Conditional processing...
  *
  **************************************************************************** */
-void skip_user_macro( tic_bool_param_t pfield )
+void skip_user_macro( tic_param_t pfield )
 {
     bool failure = true;
     char *func_cpy = strdup( statbuf);

--- a/toke/macros.h
+++ b/toke/macros.h
@@ -46,8 +46,8 @@
  **************************************************************************** */
 
 void init_macros( tic_hdr_t **tic_vocab_ptr );
-void add_user_macro( void);
-void skip_user_macro( tic_bool_param_t pfield );
+void add_user_macro( tic_param_t pfield );
+void skip_user_macro( tic_param_t pfield );
 #if  0  /*  What's this doing here?  */
 char *lookup_macro(char *name);
 bool exists_as_macro(char *name);

--- a/toke/parselocals.c
+++ b/toke/parselocals.c
@@ -228,7 +228,7 @@ static char *int_to_str( int num, char *bufr)
 
 static void invoke_local( tic_param_t pfield )
 {
-    char local_num_buf[10];
+    char local_num_buf[14];
     int loc_num = (int)pfield.deflt_elem;
 
     int_to_str(loc_num, local_num_buf);
@@ -515,8 +515,8 @@ static bool gather_locals( bool initted, int *counter )
 
 static void activate_locals( void )
 {
-    char ilocals_buf[10];
-    char ulocals_buf[10];
+    char ilocals_buf[14];
+    char ulocals_buf[14];
      
     int_to_str(num_ilocals, ilocals_buf ); 
     int_to_str(num_ulocals, ulocals_buf );
@@ -896,7 +896,7 @@ void finish_locals ( void )
      /*    Don't do anything if Locals are not in use    */
     if ( localno > 0 )
     {
-        char nlocals_buf[10];
+        char nlocals_buf[14];
      
         int_to_str(localno, nlocals_buf ); 
         sprintf( eval_buf,"%s %s",nlocals_buf, pop_locals);

--- a/toke/scanner.c
+++ b/toke/scanner.c
@@ -1539,7 +1539,6 @@ static signed long get_string( bool pack_str)
 
 static void handle_user_message( char delim, bool print_it )
 {
-    signed long wlen;
     unsigned int start_lineno = lineno;
     unsigned int multiline_start = lineno;    /*  For warning message  */
     bool check_multiline = false;
@@ -1547,7 +1546,7 @@ static void handle_user_message( char delim, bool print_it )
 
     if ( delim == '"' )
     {
-	wlen = get_string( false);
+	get_string( false);
     }else{
 	/*
 	 *  When the message-delimiter is a new-line, and the
@@ -1567,7 +1566,7 @@ static void handle_user_message( char delim, bool print_it )
 	    multiline_start = lineno;
 	    check_multiline = true;
 	}
-	wlen = get_until( delim );
+	get_until( delim );
     }
 
     if ( print_it )
@@ -4060,9 +4059,8 @@ static bool abort_quote( fwtoken tok)
 	{
 	    /* ABORT" is not enabled; we'd better consume the string  */
 	    char *save_statbuf;
-	    signed long wlen;
 	    save_statbuf = strdup( (char *)statbuf);
-	    wlen = get_string( false);
+	    get_string( false);
 	    strcpy( statbuf, save_statbuf);
 	    free( save_statbuf);
 	}else{
@@ -4074,7 +4072,6 @@ static bool abort_quote( fwtoken tok)
 	     * Presumably, Apple Source supplies its own
 	     *  IF ... THEN
 	     */
-	    char *abort_string;
 	    signed long wlen;
 
 	    retval = true;
@@ -4099,8 +4096,7 @@ static bool abort_quote( fwtoken tok)
 	}
 		
 	    if ( sun_style_abort_quote )  emit_then();
-	        /*  Sun Style  */
-		abort_string = " type -2 THROW THEN:" ;
+	        /*  Sun Style: type -2 THROW THEN:" */
 }
 	}
     return( retval );

--- a/toke/scanner.c
+++ b/toke/scanner.c
@@ -388,7 +388,7 @@ static source_state_t  *saved_source = NULL;
  *
  **************************************************************************** */
 
-void push_source( void (*res_func)(), _PTR res_parm, bool file_chg )
+void push_source( void (*res_func)(_PTR), _PTR res_parm, bool file_chg )
 {
     source_state_t  *new_sav_src;
 

--- a/toke/scanner.h
+++ b/toke/scanner.h
@@ -93,7 +93,7 @@ void init_scan_state( void );
 void	 fcode_ender( void );
 
 bool skip_until( char lim_ch);
-void push_source( void (*res_func)(), _PTR res_parm, bool is_f_chg );
+void push_source( void (*res_func)(_PTR), _PTR res_parm, bool is_f_chg );
 signed long get_word( void);
 bool get_word_in_line( char *func_nam);
 bool get_rest_of_line( void);

--- a/toke/stream.c
+++ b/toke/stream.c
@@ -909,13 +909,11 @@ static char *expand_pathname( const char *input_pathname)
     {
 	FILE *temp_file;
 	int syst_stat;
-	const char *temp_file_name = tmpnam( NULL);
 
 	/*  Use the expansion buffer for our temporary command string  */
-	sprintf( expansion_buffer,
-	    "echo %s>%s\n", input_pathname, temp_file_name);
-	syst_stat = system( expansion_buffer);
-	if ( syst_stat != 0 )
+	sprintf( expansion_buffer, "echo %s\n", input_pathname);
+	temp_file = popen( expansion_buffer, "r" );
+	if ( temp_file == NULL )
 	{
 	    tokenization_error( TKERROR,
 		"Expansion Syntax.\n");
@@ -923,13 +921,12 @@ static char *expand_pathname( const char *input_pathname)
 	    return( NULL);
 	}
 
-	temp_file = fopen( temp_file_name, "r");  /*  Cannot fail.   */
 	syst_stat = fread( expansion_buffer, 1, buffer_max, temp_file);
 	/*  Error test.  Length of what we read is not a good indicator;
 	 *      it's limited anyway by buffer_max.
 	 *  Valid test is if last character read was the new-line.
 	 */
-	if ( expansion_buffer[syst_stat-1] != '\n' )
+	if ( syst_stat == 0 || expansion_buffer[syst_stat-1] != '\n' )
 	{
 	    tokenization_error( TKERROR,
 		"Expansion buffer overflow.  Max length is %d.\n",
@@ -942,8 +939,7 @@ static char *expand_pathname( const char *input_pathname)
 	    expanded_name();
 	}
 
-	fclose( temp_file);
-	remove( temp_file_name);
+	pclose( temp_file);
     }
 
     return( retval);

--- a/toke/stream.c
+++ b/toke/stream.c
@@ -1256,7 +1256,7 @@ bool init_stream( const char *name)
 static char *extend_filename( const char *base_name, const char *new_ext)
 {
     char *retval;
-    char *ext;
+    const char *ext;
   	unsigned int len; /* should this be size_t? */
     const char *root;
 

--- a/toke/ticvocab.c
+++ b/toke/ticvocab.c
@@ -208,12 +208,12 @@ void init_tic_vocab( tic_hdr_t *tic_vocab_tbl,
  **************************************************************************** */
 
 static tic_hdr_t *make_tic_entry( char *tname,
-                        void (*tfunct)(),
+                        void (*tfunct)(tic_param_t),
                              TIC_P_DEFLT_TYPE tparam,
                                  fwtoken fw_defr,
 				     int pfldsiz,
                                          bool is_single,
-                                         void (*ign_fnc)(),
+                                         void (*ign_fnc)(tic_param_t),
                                                bool trace_this,
                                              tic_hdr_t **tic_vocab )
 {
@@ -285,12 +285,12 @@ static tic_hdr_t *make_tic_entry( char *tname,
  **************************************************************************** */
 
 void add_tic_entry( char *tname,
-                        void (*tfunct)(),
+                        void (*tfunct)(tic_param_t),
                              TIC_P_DEFLT_TYPE tparam,
                                  fwtoken fw_defr,
 				     int pfldsiz,
                                          bool is_single,
-					   void (*ign_fnc)(),
+					   void (*ign_fnc)(tic_param_t),
 					       tic_hdr_t **tic_vocab )
 {
     bool trace_this = is_on_trace_list( tname);

--- a/toke/ticvocab.h
+++ b/toke/ticvocab.h
@@ -183,7 +183,7 @@ typedef struct tic_hdr
 	tic_param_t       pfield;
 	fwtoken           fword_defr;    /*  FWord Token of entry's Definer  */
 	bool              is_token;      /*  Is entry a single-token FCode?  */
-	void            (*ign_func)();   /*  Function in "Ignored" segment   */
+	void            (*ign_func)(tic_param_t);   /*  Function in "Ignored" segment   */
 	int               pfld_size;
 	bool              tracing;       /*  TRUE if Invoc'n Msg required    */
     }  tic_hdr_t ;
@@ -208,11 +208,11 @@ typedef struct tic_fwt_hdr
     {
         char               *name;
 	struct tic_fwt_hdr *next;
-	void              (*funct)();    /*  Function for active processing  */
+	void              (*funct)(tic_param_t);    /*  Function for active processing  */
 	tic_fwt_param_t     pfield;
 	fwtoken             fword_defr;  /*  FWord Token of entry's Definer  */
 	bool                is_token;    /*  Is entry a single-token FCode?  */
-	void              (*ign_func)(); /*  Function in "Ignored" segment   */
+	void              (*ign_func)(tic_param_t); /*  Function in "Ignored" segment   */
 	int                 pfld_size;
 	bool                tracing;     /*  TRUE if Invoc'n Msg required    */
     }  tic_fwt_hdr_t ;
@@ -244,11 +244,11 @@ typedef struct tic_mac_hdr
     {
         char               *name;
 	struct tic_mac_hdr *next;
-	void              (*funct)();
+	void              (*funct)(tic_param_t);
 	tic_mac_param_t     pfield;
 	fwtoken             fword_defr;
 	bool                is_token;    /*  Is entry a single-token FCode?  */
-	void              (*ign_func)();
+	void              (*ign_func)(tic_param_t);
 	int                 pfld_size;
 	bool                tracing;     /*  TRUE if Invoc'n Msg required    */
     }  tic_mac_hdr_t ;
@@ -274,11 +274,11 @@ typedef struct tic_bool_hdr
     {
         char                *name;
 	struct tic_bool_hdr *next;
-	void               (*funct)();
-	tic_bool_param_t     pfield;
+	void               (*funct)(tic_param_t);
+	tic_param_t          pfield;
 	fwtoken              fword_defr;
 	bool                is_token;    /*  Is entry a single-token FCode?  */
-	void               (*ign_func)(tic_bool_param_t);
+	void               (*ign_func)(tic_param_t);
 	int                  pfld_size;
 	bool                 tracing;    /*  TRUE if Invoc'n Msg required    */
     }  tic_bool_hdr_t ;
@@ -471,7 +471,7 @@ typedef struct tic_bool_hdr
  **************************************************************************** */
 
 #define BUILTIN_BOOL_TIC(nam, func, bool_vbl )    \
-    { nam , (tic_bool_hdr_t *)NULL , func , { &bool_vbl },   \
+    { nam , (tic_bool_hdr_t *)NULL , func , { .bool_ptr = &bool_vbl },   \
         COMMON_FWORD , false , func , 0 , false }
 
 
@@ -487,12 +487,12 @@ void init_tic_vocab( tic_hdr_t *tic_vocab_tbl,
                          int max_indx,
 			     tic_hdr_t **tic_vocab_ptr);
 void add_tic_entry( char *tname,
-                        void (*tfunct)(),
+                        void (*tfunct)(tic_param_t),
                              TIC_P_DEFLT_TYPE tparam,
                                  fwtoken fw_defr,
 				     int pfldsiz,
                                          bool is_single,
-                                         void (*ign_fnc)(),
+                                         void (*ign_fnc)(tic_param_t),
                                              tic_hdr_t **tic_vocab );
 tic_hdr_t *lookup_tic_entry( char *tname, tic_hdr_t *tic_vocab );
 bool exists_in_tic_vocab( char *tname, tic_hdr_t *tic_vocab );


### PR DESCRIPTION
This series fixes up compile warnings on GCC 15 and then enables `-Werror` to help maintain the quality of the codebase going forward.

With thanks to @lygstate for doing the work updating the TIC handler functions, and for help with testing.
